### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ An MCP server for all my rules, prompts, etc etc. Allows agents to call rules on
 
 Spiritually similar to Cursor's rules.
 
+<a href="https://glama.ai/mcp/servers/@markacianfrani/mcp-pattern-language">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@markacianfrani/mcp-pattern-language/badge" alt="Rules Server MCP server" />
+</a>
+
 ## Usage
 
 ### Claude Code


### PR DESCRIPTION
This PR adds a badge for the [Rules MCP Server](https://glama.ai/mcp/servers/@markacianfrani/mcp-pattern-language) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@markacianfrani/mcp-pattern-language">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@markacianfrani/mcp-pattern-language/badge" alt="Rules Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.